### PR TITLE
must open xhr before calling setRequestHeader

### DIFF
--- a/test/unsafe_headers_test.js
+++ b/test/unsafe_headers_test.js
@@ -2,6 +2,7 @@ var xhr;
 module("setting unsafe header mirrors browser behavior and throws", {
   setup: function(){
     xhr = new FakeXMLHttpRequest();
+    xhr.open('GET', '/');
   },
   teardown: function(){
     window.xhr = undefined;
@@ -9,73 +10,109 @@ module("setting unsafe header mirrors browser behavior and throws", {
 });
 
 test("Accept-Charset", function(){
-  throws(function(){  xhr.setRequestHeader("Accept-Charset", '...'); })
+  throws(function(){
+    xhr.setRequestHeader("Accept-Charset", '...');
+  }, /Refused to set unsafe header.*Accept\-Charset/);
 });
 
 test("Accept-Encoding", function(){
-  throws(function(){  xhr.setRequestHeader("Accept-Encoding", '...'); })
+  throws(function(){
+    xhr.setRequestHeader("Accept-Encoding", '...');
+  }, /Refused to set unsafe header.*Accept\-Encoding/);
 });
 
 test("Connection", function(){
-  throws(function(){  xhr.setRequestHeader("Connection", '...'); })
+  throws(function(){
+    xhr.setRequestHeader("Connection", '...');
+  }, /Refused to set unsafe header.*Connection/);
 });
 
 test("Content-Length", function(){
-  throws(function(){  xhr.setRequestHeader("Content-Length", '...'); })
+  throws(function(){
+    xhr.setRequestHeader("Content\-Length", '...');
+  }, /Refused to set unsafe header.*Content\-Length/);
 });
 
 test("Cookie", function(){
-  throws(function(){  xhr.setRequestHeader("Cookie", '...'); })
+  throws(function(){
+    xhr.setRequestHeader("Cookie", '...');
+  }, /Refused to set unsafe header.*Cookie/);
 });
 
 test("Cookie2", function(){
-  throws(function(){  xhr.setRequestHeader("Cookie2", '...'); })
+  throws(function(){
+    xhr.setRequestHeader("Cookie2", '...');
+  }, /Refused to set unsafe header.*Cookie2/);
 });
 
 test("Content-Transfer-Encoding", function(){
-  throws(function(){  xhr.setRequestHeader("Content-Transfer-Encoding", '...'); })
+  throws(function(){
+    xhr.setRequestHeader("Content-Transfer-Encoding", '...');
+  }, /Refused to set unsafe header.*Content\-Transfer\-Encoding/);
 });
 
 test("Date", function(){
-  throws(function(){  xhr.setRequestHeader("Date", '...'); })
+  throws(function(){
+    xhr.setRequestHeader("Date", '...');
+  }, /Refused to set unsafe header.*Date/);
 });
 
 test("Expect", function(){
-  throws(function(){  xhr.setRequestHeader("Expect", '...'); })
+  throws(function(){
+    xhr.setRequestHeader("Expect", '...');
+  }, /Refused to set unsafe header.*Expect/);
 });
 
 test("Host", function(){
-  throws(function(){  xhr.setRequestHeader("Host", '...'); })
+  throws(function(){
+    xhr.setRequestHeader("Host", '...');
+  }, /Refused to set unsafe header.*Host/);
 });
 
 test("Keep-Alive", function(){
-  throws(function(){  xhr.setRequestHeader("Keep-Alive", '...'); })
+  throws(function(){
+    xhr.setRequestHeader("Keep-Alive", '...');
+  }, /Refused to set unsafe header.*Keep-Alive/);
 });
 
 test("Referer", function(){
-  throws(function(){  xhr.setRequestHeader("Referer", '...'); })
+  throws(function(){
+    xhr.setRequestHeader("Referer", '...');
+  }, /Refused to set unsafe header.*Referer/);
 });
 
 test("TE", function(){
-  throws(function(){  xhr.setRequestHeader("TE", '...'); })
+  throws(function(){
+    xhr.setRequestHeader("TE", '...');
+  }, /Refused to set unsafe header.*TE/);
 });
 
 test("Trailer", function(){
-  throws(function(){  xhr.setRequestHeader("Trailer", '...'); })
+  throws(function(){
+    xhr.setRequestHeader("Trailer", '...');
+  }, /Refused to set unsafe header.*Trailer/);
 });
 
 test("Transfer-Encoding", function(){
-  throws(function(){  xhr.setRequestHeader("Transfer-Encoding", '...'); })
+  throws(function(){
+    xhr.setRequestHeader("Transfer-Encoding", '...');
+  }, /Refused to set unsafe header.*Transfer\-Encoding/);
 });
 
 test("Upgrade", function(){
-  throws(function(){  xhr.setRequestHeader("Upgrade", '...'); })
+  throws(function(){
+    xhr.setRequestHeader("Upgrade", '...');
+  }, /Refused to set unsafe header.*Upgrade/);
 });
 
 test("User-Agent", function(){
-  throws(function(){  xhr.setRequestHeader("User-Agent", '...'); })
+  throws(function(){
+    xhr.setRequestHeader("User-Agent", '...');
+  }, /Refused to set unsafe header.*User\-Agent/);
 });
 
 test("Via", function(){
-  throws(function(){  xhr.setRequestHeader("Via", '...'); })
+  throws(function(){
+    xhr.setRequestHeader("Via", '...');
+  }, /Refused to set unsafe header.*Via/);
 });


### PR DESCRIPTION
The code calls [`verifyState(this)`](https://github.com/pretenderjs/FakeXMLHttpRequest/blob/7e3882e773c60d3d04ea3ab8991d38ea4e7a68da/src/fake-xml-http-request.js#L248) in `setRequestHeader`. `verifyState` will [throw an "INVALID_STATE_ERR" error](https://github.com/pretenderjs/FakeXMLHttpRequest/blob/7e3882e773c60d3d04ea3ab8991d38ea4e7a68da/src/fake-xml-http-request.js#L456-L464) if the xhr hasn't had `open` called on it yet.

As a result, the tests for setting unsafe headers were all vacuously passing. They all throw the "INVALID_STATE_ERR" error instead of the expected one. Calling `xhr.open` in the test setup ensures the expected errors will be thrown when trying to set unsafe headers.