### PR TITLE
Set Content-Type for non-GET/HEAD requests if not explicitly set

### DIFF
--- a/fake_xml_http_request.js
+++ b/fake_xml_http_request.js
@@ -271,11 +271,8 @@
       verifyState(this);
 
       if (!/^(get|head)$/i.test(this.method)) {
-        if (this.requestHeaders["Content-Type"]) {
-          var value = this.requestHeaders["Content-Type"].split(";");
-          this.requestHeaders["Content-Type"] = value[0] + ";charset=utf-8";
-        } else {
-          this.requestHeaders["Content-Type"] = "text/plain;charset=utf-8";
+        if (!this.requestHeaders["Content-Type"]) {
+          this.requestHeaders["Content-Type"] = "text/plain;charset=UTF-8";
         }
 
         this.requestBody = data;

--- a/src/fake-xml-http-request.js
+++ b/src/fake-xml-http-request.js
@@ -265,11 +265,8 @@ var FakeXMLHttpRequestProto = {
     verifyState(this);
 
     if (!/^(get|head)$/i.test(this.method)) {
-      if (this.requestHeaders["Content-Type"]) {
-        var value = this.requestHeaders["Content-Type"].split(";");
-        this.requestHeaders["Content-Type"] = value[0] + ";charset=utf-8";
-      } else {
-        this.requestHeaders["Content-Type"] = "text/plain;charset=utf-8";
+      if (!this.requestHeaders["Content-Type"]) {
+        this.requestHeaders["Content-Type"] = "text/plain;charset=UTF-8";
       }
 
       this.requestBody = data;

--- a/test/send_test.js
+++ b/test/send_test.js
@@ -1,0 +1,26 @@
+var xhr;
+module("send", {
+  setup: function(){
+    xhr = new FakeXMLHttpRequest();
+  },
+  teardown: function(){
+    xhr = undefined;
+  }
+});
+
+test("sets Content-Type header for non-GET/HEAD requests if not set", function(){
+  xhr.open("POST", "/");
+  xhr.send("data");
+  equal(xhr.requestHeaders["Content-Type"], "text/plain;charset=UTF-8",
+        "sets content-type when not set");
+});
+
+test("does not change Content-Type if explicitly set for non-GET/HEAD", function(){
+  xhr.open("POST", "/");
+  xhr.setRequestHeader("Content-Type", "application/json");
+  xhr.send("data");
+  equal(xhr.requestHeaders["Content-Type"], "application/json",
+        "does not change existing content-type header");
+});
+
+


### PR DESCRIPTION
Changes `fakeXHR#send` to only set a Content-Type for non-GET, non-HEAD requests if the user didn't already set the Content-Type. Removes the code that appended ";charset=utf-8" to the user-supplied Content-Type. There is some more context in #14 about why this might be a good idea. In short, it allows users of Pretender to passthrough an xhr request with the Content-Type intact, which matters in certain situations like uploading to a pre-signed URL when the signature was calculated based on the Content-Type.

Closes #14

(Apologies for the slew of small PRs in a row here.)