### PR TITLE
Pass an event to onreadystatechange handler

### DIFF
--- a/fake_xml_http_request.js
+++ b/fake_xml_http_request.js
@@ -362,7 +362,7 @@
       this.readyState = state;
 
       if (typeof this.onreadystatechange == "function") {
-        this.onreadystatechange();
+        this.onreadystatechange(new _Event("readystatechange"));
       }
 
       this.dispatchEvent(new _Event("readystatechange"));

--- a/src/fake-xml-http-request.js
+++ b/src/fake-xml-http-request.js
@@ -356,7 +356,7 @@ var FakeXMLHttpRequestProto = {
     this.readyState = state;
 
     if (typeof this.onreadystatechange == "function") {
-      this.onreadystatechange();
+      this.onreadystatechange(new _Event("readystatechange"));
     }
 
     this.dispatchEvent(new _Event("readystatechange"));

--- a/test/open_test.js
+++ b/test/open_test.js
@@ -59,14 +59,14 @@ test("open sets the ready state to 1", function(){
   equal(xhr.readyState, 1)
 });
 
-test("triggers the onreadystatechange event", function(){
-  var wasCalled = false;
+test("triggers the onreadystatechange event with OPENED readyState", function(){
+  var readyState = null;
 
   xhr.onreadystatechange = function(){
-    wasCalled = true;
-  }
+    readyState = this.readyState;
+  };
 
   xhr.open('get', '/some/url');
 
-  ok(wasCalled);
+  equal(readyState, FakeXMLHttpRequest.OPENED);
 });

--- a/test/responding_test.js
+++ b/test/responding_test.js
@@ -72,3 +72,35 @@ test("calls the onload callback once", function(){
 
   strictEqual(wasCalled, 1);
 });
+
+test("calls onreadystatechange for each state change", function() {
+  var states = [];
+
+  xhr.onreadystatechange = function() {
+    states.push(this.readyState);
+  };
+
+  xhr.open('get', '/some/url');
+
+  xhr.respond(200, {}, "");
+
+  var expectedStates = [
+    FakeXMLHttpRequest.OPENED,
+    FakeXMLHttpRequest.HEADERS_RECEIVED,
+    FakeXMLHttpRequest.LOADING,
+    FakeXMLHttpRequest.DONE
+  ];
+  deepEqual(states, expectedStates);
+});
+
+test("passes event to onreadystatechange", function() {
+  var event = null;
+  xhr.onreadystatechange = function(e) {
+    event = e;
+  };
+  xhr.open('get', '/some/url');
+  xhr.respond(200, {}, "");
+
+  ok(event && event.type === 'readystatechange',
+     'passes event with type "readystatechange"');
+});

--- a/test/send_test.js
+++ b/test/send_test.js
@@ -22,5 +22,3 @@ test("does not change Content-Type if explicitly set for non-GET/HEAD", function
   equal(xhr.requestHeaders["Content-Type"], "application/json",
         "does not change existing content-type header");
 });
-
-


### PR DESCRIPTION
This fixes an issue that can arise when used with a Pretender passthrough request. FakeXHR will call `onreadystatechange()`. This property will [have been defined by Pretender](https://github.com/pretenderjs/pretender/blob/cb18081ede811eb288e67634de71c130ce1eddcb/pretender.js#L159)'s `createPassthrough`, which in turn calls the `dispatchEvent` method on the FakeXHR instance, which will then error because it will have been called without passing an event (`dispatchEvent` [checks for `event.type`](https://github.com/pretenderjs/FakeXMLHttpRequest/blob/52210b098c6233d7ceae8a0e13f4668ab45461f7/src/fake-xml-http-request.js#L170)).

Always passing an event to `onreadystatechange` fixes this.