### PR TITLE
Don't auto set content type header for multipart/form-data

### DIFF
--- a/fake_xml_http_request.js
+++ b/fake_xml_http_request.js
@@ -272,7 +272,7 @@
       verifyState(this);
 
       if (!/^(get|head)$/i.test(this.method)) {
-        if (!this.requestHeaders["Content-Type"]) {
+        if (!this.requestHeaders["Content-Type"] && !(data || '').toString().match('FormData')) {
           this.requestHeaders["Content-Type"] = "text/plain;charset=UTF-8";
         }
 

--- a/src/fake-xml-http-request.js
+++ b/src/fake-xml-http-request.js
@@ -266,7 +266,7 @@ var FakeXMLHttpRequestProto = {
     verifyState(this);
 
     if (!/^(get|head)$/i.test(this.method)) {
-      if (!this.requestHeaders["Content-Type"]) {
+      if (!this.requestHeaders["Content-Type"] && !(data || '').toString().match('FormData')) {
         this.requestHeaders["Content-Type"] = "text/plain;charset=UTF-8";
       }
 

--- a/test/send_test.js
+++ b/test/send_test.js
@@ -22,3 +22,10 @@ test("does not change Content-Type if explicitly set for non-GET/HEAD", function
   equal(xhr.requestHeaders["Content-Type"], "application/json",
         "does not change existing content-type header");
 });
+
+test("does not set Content-Type if data is FormData object", function(){
+  xhr.open("POST", "/");
+  xhr.send(new FormData());
+  equal(xhr.requestHeaders["Content-Type"], null,
+        "does not set content-type header for FormData POSTs");
+});


### PR DESCRIPTION
When using `pretender.passthrough` to pass through an AJAX file upload that was made using something like this:

```js
$.ajax({
  url: url,
  type: 'POST',
  data: formData,
  processData: false,
  contentType: false
})
```

The `multipart/form-data` content type and `boundary` weren't being set properly by the browser because this was overriding the `contentType: false` and setting it to `text/plain`