### PR TITLE
Treat package as a global for jspm env

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "karma-firefox-launcher": "~0.1.4",
     "karma-phantomjs-launcher": "~0.1.4",
     "karma-qunit": "~0.1.4"
+  },
+  "jspm": {
+    "format": "global"
   }
 }


### PR DESCRIPTION
Without this override pretender can't find the [FakeXMLHttpRequest](https://github.com/pretenderjs/pretender/blob/0.10.1/pretender.js#L9) object.