### PR TITLE
Support overrideMimeType() method

### DIFF
--- a/fake_xml_http_request.js
+++ b/fake_xml_http_request.js
@@ -355,6 +355,16 @@
     },
 
     /*
+     Duplicates the behavior of native XMLHttpRequest's overrideMimeType function
+     */
+    overrideMimeType: function overrideMimeType(mimeType) {
+      if (typeof mimeType === "string") {
+        this.forceMimeType = mimeType.toLowerCase();
+      }
+    },
+
+
+    /*
       Places a FakeXMLHttpRequest object into the passed
       state.
     */
@@ -385,6 +395,10 @@
         if (headers.hasOwnProperty(header)) {
             this.responseHeaders[header] = headers[header];
         }
+      }
+
+      if (this.forceMimeType) {
+        this.responseHeaders['Content-Type'] = this.forceMimeType;
       }
 
       if (this.async) {

--- a/src/fake-xml-http-request.js
+++ b/src/fake-xml-http-request.js
@@ -349,6 +349,16 @@ var FakeXMLHttpRequestProto = {
   },
 
   /*
+   Duplicates the behavior of native XMLHttpRequest's overrideMimeType function
+   */
+  overrideMimeType: function overrideMimeType(mimeType) {
+    if (typeof mimeType === "string") {
+      this.forceMimeType = mimeType.toLowerCase();
+    }
+  },
+
+
+  /*
     Places a FakeXMLHttpRequest object into the passed
     state.
   */
@@ -379,6 +389,10 @@ var FakeXMLHttpRequestProto = {
       if (headers.hasOwnProperty(header)) {
           this.responseHeaders[header] = headers[header];
       }
+    }
+
+    if (this.forceMimeType) {
+      this.responseHeaders['Content-Type'] = this.forceMimeType;
     }
 
     if (this.async) {

--- a/test/responding_test.js
+++ b/test/responding_test.js
@@ -104,3 +104,21 @@ test("passes event to onreadystatechange", function() {
   ok(event && event.type === 'readystatechange',
      'passes event with type "readystatechange"');
 });
+
+test("overrideMimeType overrides content-type responseHeader", function(){
+  xhr.overrideMimeType('text/plain');
+  xhr.respond(200, {"Content-Type":"application/json"});
+  deepEqual(xhr.responseHeaders, {"Content-Type":"text/plain"});
+});
+
+test("parses the body if it's XML and overrideMimeType is set to xml", function(){
+  xhr.overrideMimeType('application/xml');
+  xhr.respond(200, {'Content-Type':'text/plain'}, "<key>value</key>");
+  equal(xhr.responseXML.constructor, xmlDocumentConstructor);
+});
+
+test("does not parse the body if it's XML and overrideMimeType is set to another content type", function(){
+  xhr.overrideMimeType('text/plain');
+  xhr.respond(200, {'Content-Type':'application/xml'}, "<key>value</key>");
+  equal(xhr.responseXML, undefined);
+});


### PR DESCRIPTION
The FakeXMLHttpRequest class is missing the `overrideMimeType` method, which is part of the XMLHttpRequest specification: https://www.w3.org/TR/XMLHttpRequest/#the-overridemimetype()-method. Applications or libraries relying on this method will get an "undefined is not a function" exception when using FakeXMLHttpRequest.

This PR adds the missing method and mimics its original behaviour.