### PR TITLE
Pass event target as context to `onload` handler

### DIFF
--- a/fake_xml_http_request.js
+++ b/fake_xml_http_request.js
@@ -134,7 +134,7 @@
       var listener = xhr["on" + eventName];
 
       if (listener && typeof listener == "function") {
-        listener(event);
+        listener.call(event.target, event);
       }
     });
   }

--- a/src/fake-xml-http-request.js
+++ b/src/fake-xml-http-request.js
@@ -128,7 +128,7 @@ function _addEventListener(eventName, xhr){
     var listener = xhr["on" + eventName];
 
     if (listener && typeof listener == "function") {
-      listener(event);
+      listener.call(event.target, event);
     }
   });
 }

--- a/test/responding_test.js
+++ b/test/responding_test.js
@@ -73,6 +73,20 @@ test("calls the onload callback once", function(){
   strictEqual(wasCalled, 1);
 });
 
+test("passes event target as context to onload", function() {
+  var context;
+  var event;
+
+  xhr.onload = function(ev){
+    event = ev;
+    context = this;
+  };
+
+  xhr.respond(200, {}, "");
+
+  deepEqual(context, event.target);
+});
+
 test("calls onreadystatechange for each state change", function() {
   var states = [];
 


### PR DESCRIPTION
This is normal browser behavior as seen here:
http://jsbin.com/felarepuji/edit?html,output

Fixes pretenderjs/pretender#158
