### PR TITLE
check for lowercase content-type header

### DIFF
--- a/fake_xml_http_request.js
+++ b/fake_xml_http_request.js
@@ -272,7 +272,7 @@
       verifyState(this);
 
       if (!/^(get|head)$/i.test(this.method)) {
-        if (!this.requestHeaders["Content-Type"] && !(data || '').toString().match('FormData')) {
+        if (!this.requestHeaders["Content-Type"] && !this.requestHeaders["content-type"] && !(data || '').toString().match('FormData')) {
           this.requestHeaders["Content-Type"] = "text/plain;charset=UTF-8";
         }
 

--- a/src/fake-xml-http-request.js
+++ b/src/fake-xml-http-request.js
@@ -266,7 +266,7 @@ var FakeXMLHttpRequestProto = {
     verifyState(this);
 
     if (!/^(get|head)$/i.test(this.method)) {
-      if (!this.requestHeaders["Content-Type"] && !(data || '').toString().match('FormData')) {
+      if (!this.requestHeaders["Content-Type"] && !this.requestHeaders["content-type"] && !(data || '').toString().match('FormData')) {
         this.requestHeaders["Content-Type"] = "text/plain;charset=UTF-8";
       }
 


### PR DESCRIPTION
In one of my projects we are using the github fetch polyfill (https://github.com/github/fetch) and setting a request Content-Type of `application/x-www-form-urlencoded`. In the polyfill code all custom set header names are made lowercase, this is according to specification (all header name are case insensitive (see: https://github.com/github/fetch/issues/249, https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2).

Current status is that FakeXMLHttpRequest only checks for case sensitive `Content-Type`. So in my project we end up with two content-type headers, resulting in a combined, invalid content-type of `application/x-www-form-urlencoded, text/plain; charset=UTF-8`.

This PR simply also checks for the lower-case variant.