### PR TITLE
Make Content-Type header check more resilient

### DIFF
--- a/fake_xml_http_request.js
+++ b/fake_xml_http_request.js
@@ -272,7 +272,15 @@
       verifyState(this);
 
       if (!/^(get|head)$/i.test(this.method)) {
-        if (!this.requestHeaders["Content-Type"] && !(data || '').toString().match('FormData')) {
+        var hasContentTypeHeader = false
+
+        Object.keys(this.requestHeaders).forEach(function (key) {
+          if (key.toLowerCase() === 'content-type') {
+            hasContentTypeHeader = true;
+          }
+        });
+
+        if (!hasContentTypeHeader && !(data || '').toString().match('FormData')) {
           this.requestHeaders["Content-Type"] = "text/plain;charset=UTF-8";
         }
 

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
   "license": "MIT",
   "devDependencies": {
     "esperanto": "^0.6.15",
-    "karma": "~0.12.31",
-    "karma-chrome-launcher": "~0.1.7",
-    "karma-firefox-launcher": "~0.1.4",
-    "karma-phantomjs-launcher": "~0.1.4",
-    "karma-qunit": "~0.1.4"
+    "karma": "^1.6.0",
+    "karma-chrome-launcher": "^2.0.0",
+    "karma-firefox-launcher": "^1.0.1",
+    "karma-phantomjs-launcher": "^1.0.4",
+    "karma-qunit": "^1.2.1",
+    "qunitjs": "^1.0.0"
   }
 }

--- a/src/fake-xml-http-request.js
+++ b/src/fake-xml-http-request.js
@@ -266,7 +266,15 @@ var FakeXMLHttpRequestProto = {
     verifyState(this);
 
     if (!/^(get|head)$/i.test(this.method)) {
-      if (!this.requestHeaders["Content-Type"] && !(data || '').toString().match('FormData')) {
+      var hasContentTypeHeader = false
+
+      Object.keys(this.requestHeaders).forEach(function (key) {
+        if (key.toLowerCase() === 'content-type') {
+          hasContentTypeHeader = true;
+        }
+      });
+
+      if (!hasContentTypeHeader && !(data || '').toString().match('FormData')) {
         this.requestHeaders["Content-Type"] = "text/plain;charset=UTF-8";
       }
 

--- a/test/send_test.js
+++ b/test/send_test.js
@@ -39,7 +39,7 @@ test("does not set Content-Type if CoNtEnT-tYpE explicitly set for non-GET/HEAD"
   xhr.send("data");
   equal(xhr.requestHeaders["CoNtEnT-tYpE"], "application/json",
         "does not change existing content-type header");
-  equal(xhr.requestHeaders["CoNtEnT-tYpE"], undefined,
+  equal(xhr.requestHeaders["Content-Type"], undefined,
         "does not add Content-Type header");
 });
 

--- a/test/send_test.js
+++ b/test/send_test.js
@@ -15,12 +15,32 @@ test("sets Content-Type header for non-GET/HEAD requests if not set", function()
         "sets content-type when not set");
 });
 
-test("does not change Content-Type if explicitly set for non-GET/HEAD", function(){
+test("does not change Content-Type if explicitly set for non-GET/HEAD using key Content-TYpe", function(){
   xhr.open("POST", "/");
   xhr.setRequestHeader("Content-Type", "application/json");
   xhr.send("data");
   equal(xhr.requestHeaders["Content-Type"], "application/json",
         "does not change existing content-type header");
+});
+
+test("does not set Content-Type if content-type explicitly set for non-GET/HEAD", function(){
+  xhr.open("POST", "/");
+  xhr.setRequestHeader("content-type", "application/json");
+  xhr.send("data");
+  equal(xhr.requestHeaders["content-type"], "application/json",
+        "does not change existing content-type header");
+  equal(xhr.requestHeaders["Content-Type"], undefined,
+        "does not add Content-Type header");
+});
+
+test("does not set Content-Type if CoNtEnT-tYpE explicitly set for non-GET/HEAD", function(){
+  xhr.open("POST", "/");
+  xhr.setRequestHeader("CoNtEnT-tYpE", "application/json");
+  xhr.send("data");
+  equal(xhr.requestHeaders["CoNtEnT-tYpE"], "application/json",
+        "does not change existing content-type header");
+  equal(xhr.requestHeaders["CoNtEnT-tYpE"], undefined,
+        "does not add Content-Type header");
 });
 
 test("does not set Content-Type if data is FormData object", function(){


### PR DESCRIPTION
* **Fixed** build by upgrading some packages, before doing so `npm test` wouldn't work.
* **Fixed** bug where `send()` was adding a `Content-Type` header when the header was already defined using a different casing, such as `content-type`. This issue arises when using this project in conjunction with most fetch polyfills, as they normalize headers to all lowercase.