### PR TITLE
Add response url to the XMLHttpRequest

### DIFF
--- a/fake_xml_http_request.js
+++ b/fake_xml_http_request.js
@@ -243,6 +243,7 @@
       this.password = password;
       this.responseText = null;
       this.responseXML = null;
+      this.responseURL = url;
       this.requestHeaders = {};
       this.sendFlag = false;
       this._readyStateChange(FakeXMLHttpRequest.OPENED);

--- a/src/fake-xml-http-request.js
+++ b/src/fake-xml-http-request.js
@@ -237,6 +237,7 @@ var FakeXMLHttpRequestProto = {
     this.password = password;
     this.responseText = null;
     this.responseXML = null;
+    this.responseURL = url;
     this.requestHeaders = {};
     this.sendFlag = false;
     this._readyStateChange(FakeXMLHttpRequest.OPENED);

--- a/test/open_test.js
+++ b/test/open_test.js
@@ -48,6 +48,11 @@ test("initializes the responseXML as null", function(){
   equal(xhr.responseXML, null);
 });
 
+test("initializes the responseURL as the opened url", function(){
+  xhr.open('get', '/some/url');
+  equal(xhr.responseURL, '/some/url');
+});
+
 test("initializes the requestHeaders property as empty object", function(){
   xhr.open('get', '/some/url');
   deepEqual(xhr.requestHeaders, {});


### PR DESCRIPTION
When using the fetch API, the `response` object has a `url` property which is the final URL that ended up being accessed.

The fetch polyfill populates this property by looking at the [responseURL](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseURL) property of the XHR.

However, because FakeXHR, does not set this property, pretender will not work with systems that use fetch and the `url` property of the subsequent `Response`. (like [this one](https://github.com/folio-org/stripes-connect/blob/master/RESTResource/RESTResource.js#L532)

This small change copies over the the `url` argument passed to `open` and uses it as the `responseURL` of the XHR.

Theoretically, the responseURL could be different than the opened url, but only if a re-direct happened. As far as I can tell though, FakeXHR doesn't handle re-directs so this shouldn't be an issue.