### PR TITLE
Add requestBody and requestHeaders to types declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,7 @@
 export default class FakeXMLHttpRequest extends XMLHttpRequest {
+  requestBody: string;
+
+  requestHeaders: {[k: string]: string};
   /*
     Forces a response on to the FakeXMLHttpRequest object.
 


### PR DESCRIPTION
Following https://github.com/pretenderjs/pretender/pull/278

XMLHttpRequest is not specifying said properties and are therefore not
inheried by FakeXMLHttpRequest by extending it. So those need to be
referenced in this project's types declaration.