### PR TITLE
alias responseText to response

### DIFF
--- a/fake_xml_http_request.js
+++ b/fake_xml_http_request.js
@@ -242,6 +242,7 @@
       this.username = username;
       this.password = password;
       this.responseText = null;
+      this.response = this.responseText;
       this.responseXML = null;
       this.responseURL = url;
       this.requestHeaders = {};
@@ -305,6 +306,7 @@
     abort: function abort() {
       this.aborted = true;
       this.responseText = null;
+      this.response = this.responseText;
       this.errorFlag = true;
       this.requestHeaders = {};
 
@@ -431,6 +433,7 @@
       var chunkSize = this.chunkSize || 10;
       var index = 0;
       this.responseText = "";
+      this.response = this.responseText;
 
       do {
         if (this.async) {
@@ -438,6 +441,7 @@
         }
 
         this.responseText += body.substring(index, index + chunkSize);
+        this.response = this.responseText;
         index += chunkSize;
       } while (index < body.length);
 

--- a/src/fake-xml-http-request.js
+++ b/src/fake-xml-http-request.js
@@ -236,6 +236,7 @@ var FakeXMLHttpRequestProto = {
     this.username = username;
     this.password = password;
     this.responseText = null;
+    this.response = this.responseText;
     this.responseXML = null;
     this.responseURL = url;
     this.requestHeaders = {};
@@ -299,6 +300,7 @@ var FakeXMLHttpRequestProto = {
   abort: function abort() {
     this.aborted = true;
     this.responseText = null;
+    this.response = this.responseText;
     this.errorFlag = true;
     this.requestHeaders = {};
 
@@ -425,6 +427,7 @@ var FakeXMLHttpRequestProto = {
     var chunkSize = this.chunkSize || 10;
     var index = 0;
     this.responseText = "";
+    this.response = this.responseText;
 
     do {
       if (this.async) {
@@ -432,6 +435,7 @@ var FakeXMLHttpRequestProto = {
       }
 
       this.responseText += body.substring(index, index + chunkSize);
+      this.response = this.responseText;
       index += chunkSize;
     } while (index < body.length);
 

--- a/test/aborting_test.js
+++ b/test/aborting_test.js
@@ -18,6 +18,11 @@ test("sets responseText to null", function(){
   equal(xhr.responseText, null);
 });
 
+test("sets response to null", function(){
+  xhr.abort();
+  equal(xhr.response, null);
+});
+
 test("sets errorFlag to true", function(){
   xhr.abort();
   equal(xhr.errorFlag, true);

--- a/test/open_test.js
+++ b/test/open_test.js
@@ -43,6 +43,11 @@ test("initializes the responseText as null", function(){
   equal(xhr.responseText, null);
 });
 
+test("initializes the response as null", function(){
+  xhr.open('get', '/some/url');
+  equal(xhr.response, null);
+});
+
 test("initializes the responseXML as null", function(){
   xhr.open('get', '/some/url');
   equal(xhr.responseXML, null);

--- a/test/responding_test.js
+++ b/test/responding_test.js
@@ -44,6 +44,7 @@ test("sets responseHeaders", function(){
 test("sets body", function(){
   xhr.respond(200, {"Content-Type":"application/json"}, JSON.stringify({a: 'key'}));
   equal(xhr.responseText, '{"a":"key"}');
+  equal(xhr.response, '{"a":"key"}');
 });
 
 test("parses the body if it's XML and no content-type is set", function(){


### PR DESCRIPTION
I'm dealing with a situation where switching to pretender is causing Three.js's file loading to fail. They assume the request has both a `responseText` and a `response` property.

<img width="301" alt="Screenshot 2019-11-06 at 16 21 32" src="https://user-images.githubusercontent.com/602423/68317570-42ea0380-00b3-11ea-8746-f9fbf19895b4.png">

Here is the offending code https://github.com/mrdoob/three.js/blob/6fcaa8ef3dac2640a88901f2efd37d42acb82b7c/src/loaders/FileLoader.js#L173.